### PR TITLE
optamized code

### DIFF
--- a/Group Anagrams.cpp
+++ b/Group Anagrams.cpp
@@ -1,35 +1,38 @@
-struct RetrieveValue
-{   
-    template <typename T>
-    typename T::second_type operator()(T keyValuePair) const
-    {   
-        return keyValuePair.second;
-    }
-};
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <algorithm>
+
+using namespace std;
 
 class Solution {
 public:
     vector<vector<string>> groupAnagrams(vector<string>& strs) {
         unordered_map<string, vector<string>> groups;
-        
-        for(string& str : strs){
+
+        for (const string& str : strs) {
             vector<int> count(26, 0);
-            for(char c : str){
-                count[c-'a']++;
+            for (char c : str) {
+                count[c - 'a']++;
             }
-            
-            string scount = "";
-            for(int& e : count){
-                scount += (to_string(e)+"#");
+
+            // Create a unique key from the count array
+            string key;
+            for (int e : count) {
+                key += to_string(e) + '#';
             }
-            
-            groups[scount].push_back(str);
+
+            groups[key].push_back(str);
         }
-        
+
+        // Reserve space for performance
         vector<vector<string>> ans;
+        ans.reserve(groups.size());
         
-        transform(groups.begin(), groups.end(), back_inserter(ans), RetrieveValue());
-        
+        for (auto& entry : groups) {
+            ans.push_back(move(entry.second)); // Move to avoid copying
+        }
+
         return ans;
     }
 };


### PR DESCRIPTION
Use const string& in the Loop: This avoids unnecessary copies when iterating through the input vector.

String Key Construction: Instead of using a separate variable to create the key, we can directly construct it in a single loop. This is more straightforward and avoids potential confusion.

Reserve Space for the Result: By reserving space for the ans vector, we can reduce the number of reallocations that might occur as we push back results.

Move Semantics: When adding the grouped strings to the result, using move transfers ownership without copying, which can improve performance when dealing with larger strings.